### PR TITLE
Enable support for downloading export data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Python script to pull energy consumption data from Octopus energy into InfluxDB.
 | `OCTOPUS_API_KEY` | API key for accessing Octopus Energy APIs. You can generate this key from [here](https://octopus.energy/dashboard/developer/). | ✔️ | Requeired |
 | `ELECTRICITY_MPAN` | MPAN for your electricity meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. | ✔️ | Requeired |
 | `ELECTRICITY_SERIAL_NO` | Serial number of your electricity meter. You will find it on your electricity meter. | ✔️ | Requeired |
+| `EXPORT_MPAN` | MPAN for your electricity export meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. Export download will be skipped if not provided. | ❌ | None |
+| `EXPORT_SERIAL_NO` | Serial number of your electricity export meter. You will find it on your electricity meter. | ✔️ (if EXPORT_MPAN is configured) | Required |
 | `GAS_MPAN` | MPAN for your gas meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. | ✔️ | Requeired |
 | `GAS_SERIAL_NO` | Serial number of your gas meter. You will find it on your gas meter. | ✔️ | Requeired |
 | `VOLUME_CORRECTION_FACTOR` | Factor to convert m3 into kWh. You will find this on your last gas bill from Octopus. | ✔️ | Requeired |

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Python script to pull energy consumption data from Octopus energy into InfluxDB.
 | `INFLUX_DB_PORT` | Port on which influx DB is running | ❌ | 8086 |
 | `INFLUX_DB_USER` | InfluxDB user if authentication set. | ❌ | "" |
 | `INFLUX_DB_PASSWORD` | InfluxDB password if authentication set. | ❌ | "" |
-| `OCTOPUS_API_KEY` | API key for accessing Octopus Energy APIs. You can generate this key from [here](https://octopus.energy/dashboard/developer/). | ✔️ | Requeired |
-| `ELECTRICITY_MPAN` | MPAN for your electricity meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. | ✔️ | Requeired |
-| `ELECTRICITY_SERIAL_NO` | Serial number of your electricity meter. You will find it on your electricity meter. | ✔️ | Requeired |
+| `OCTOPUS_API_KEY` | API key for accessing Octopus Energy APIs. You can generate this key from [here](https://octopus.energy/dashboard/developer/). | ✔️ | Required |
+| `ELECTRICITY_MPAN` | MPAN for your electricity meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. | ✔️ | Required |
+| `ELECTRICITY_SERIAL_NO` | Serial number of your electricity meter. You will find it on your electricity meter. | ✔️ | Required |
 | `EXPORT_MPAN` | MPAN for your electricity export meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. Export download will be skipped if not provided. | ❌ | None |
 | `EXPORT_SERIAL_NO` | Serial number of your electricity export meter. You will find it on your electricity meter. | ✔️ (if EXPORT_MPAN is configured) | Required |
-| `GAS_MPAN` | MPAN for your gas meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. | ✔️ | Requeired |
-| `GAS_SERIAL_NO` | Serial number of your gas meter. You will find it on your gas meter. | ✔️ | Requeired |
-| `VOLUME_CORRECTION_FACTOR` | Factor to convert m3 into kWh. You will find this on your last gas bill from Octopus. | ✔️ | Requeired |
+| `GAS_MPAN` | MPAN for your gas meter. [Here](https://www.comparethemarket.com/energy/content/mpan-number/) the guide on how to find it. | ✔️ | Required |
+| `GAS_SERIAL_NO` | Serial number of your gas meter. You will find it on your gas meter. | ✔️ | Required |
+| `VOLUME_CORRECTION_FACTOR` | Factor to convert m3 into kWh. You will find this on your last gas bill from Octopus. | ✔️ | Required |
 | `SERIES_START_DATE` | Inital date from which the script will load the data. This date should be the date in the past. | ❌ | Yesterday's date |
 
 ## Usage:

--- a/consumption_exporter.py
+++ b/consumption_exporter.py
@@ -31,7 +31,7 @@ def _get_query_date_range(connection, series):
         latest_time = result.raw['series'][0]['values'][0][0]
         click.echo(f"Latest entry for series {series} is on {latest_time}.")
         from_date = parser.parse(latest_time)
-        to_date = from_date + timedelta(days=1)
+        to_date = datetime.now()
         return from_date.isoformat(), to_date.isoformat()
     else:
         # DB empty (i.e. running first time) or something wrong with series. Drop series if data already there.

--- a/consumption_exporter.py
+++ b/consumption_exporter.py
@@ -60,6 +60,23 @@ def _pull_electricity_consumption(connection, api_key):
     click.echo(f"Loaded elctricity data between {from_date} to {to_date}. {len(e_consumption)} results found.")
     store_series(connection, 'electricity', e_consumption, conversion_factor=None)
 
+def _pull_electricity_export(connection, api_key):
+    e_mpan = os.getenv('EXPORT_MPAN')
+    if not e_mpan:
+         click.echo("Export MPAN not configured")
+         return
+
+    e_serial = os.getenv('EXPORT_SERIAL_NO')
+    if not e_serial:
+         raise click.ClickException('No serial number set for export meter.')
+
+    e_url = f'https://api.octopus.energy/v1/electricity-meter-points/{e_mpan}/meters/{e_serial}/consumption/'
+
+    from_date, to_date = _get_query_date_range(connection, "electricity_export")
+    e_consumption = retrieve_paginated_data(api_key, e_url, from_date, to_date)
+    click.echo(f"Loaded electricity export data between {from_date} to {to_date}. {len(e_consumption)} results found.")
+    store_series(connection, 'electricity_export', e_consumption, conversion_factor=None)
+    
 def _pull_gas_consumption(connection, api_key):
     from_date, to_date = _get_query_date_range(connection, "gas")
 
@@ -135,6 +152,7 @@ def monitor():
 
     while True:
         _pull_electricity_consumption(influx, api_key)
+        _pull_electricity_export(influx, api_key)
         _pull_gas_consumption(influx, api_key)
         _sleep_until_2am() 
         


### PR DESCRIPTION
Updating script to download export data into a new series (electricity_export) when configured. Export is not required and will be skipped if an export MPAN isn't provided.